### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+enquiries
+fade
+gitpython
+colorama
+pyyaml


### PR DESCRIPTION
Adds a `requirements.txt` file that contains the required modules. It can be used to download them with this command:
```
pip install -r requirements.txt
```