### PR TITLE
bugfix - change an integer into a float again

### DIFF
--- a/data/start.yaml
+++ b/data/start.yaml
@@ -10,8 +10,8 @@ held leggings: Old Pants
 held shield: " "
 inventory slots: 9
 inventory slots remaining: 4
-elapsed time seconds: 0
-elapsed time game days: 0
+elapsed time seconds: 0.
+elapsed time game days: 0.
 used keys:
 - None
 visited zones:


### PR DESCRIPTION
It seems #2 was overridden with commit d5db44d11663b64815ddc387f2712f3aa8b1af7d. This fixes that.

Oh, and by the way, I would prefer it if you squash merged.