### PR TITLE
FEATURE: Game Data Download Customization

### DIFF
--- a/schemas/preferences.yaml
+++ b/schemas/preferences.yaml
@@ -6,3 +6,7 @@ speed up: bool()
 theme: str()
 title style: int(max=2, min=1)
 auto update: bool()
+game data download:
+  org: str()
+  repository: str()
+  branch: str()

--- a/source/main.py
+++ b/source/main.py
@@ -103,7 +103,8 @@ if not os.path.exists(program_dir):
         "speed up": False,
         "theme": 'greenblue',
         "title style": 1,
-        "auto update": True
+        "auto update": True,
+        "branch": "master"
     }
     default_config_data = yaml.dump(default_config_data)
     with open(program_dir + '/preferences.yaml', 'w') as f:
@@ -124,13 +125,14 @@ if preferences["auto update"]:
     print("Download game data...")
     print("This may take a few seconds, sorry for the waiting.")
     print("0/4", end="\r")
+    download_branch = str(preferences["branch"])
 
     logger_sys.log_message("INFO: Downloading game yaml schemas files from github")
 
     # Download yaml schema files
     try:
         destination = program_dir + '/game/schemas'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs")
+        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
         fs.get(fs.ls("schemas/"), destination)
     except Exception as error:
         print(
@@ -149,7 +151,7 @@ if preferences["auto update"]:
     # Download data files
     try:
         destination = program_dir + '/game/data'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs")
+        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
         fs.get(fs.ls("data/"), destination)
     except Exception as error:
         print(
@@ -168,7 +170,7 @@ if preferences["auto update"]:
     # Download images .txt files
     try:
         destination = program_dir + '/game/imgs'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs")
+        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
         fs.get(fs.ls("imgs/"), destination)
     except Exception as error:
         print(
@@ -187,7 +189,7 @@ if preferences["auto update"]:
     # Download images .txt files
     try:
         destination = program_dir + '/game/scripts'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs")
+        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
         fs.get(fs.ls("scripts/"), destination)
     except Exception as error:
         print(

--- a/source/main.py
+++ b/source/main.py
@@ -104,7 +104,11 @@ if not os.path.exists(program_dir):
         "theme": 'greenblue',
         "title style": 1,
         "auto update": True,
-        "branch": "master"
+        "game data download": {
+            "branch": "master",
+            "repository": "Bane-Of-Wargs",
+            "org": "Dungeons-Of-Kathallion"
+        }
     }
     default_config_data = yaml.dump(default_config_data)
     with open(program_dir + '/preferences.yaml', 'w') as f:
@@ -125,14 +129,16 @@ if preferences["auto update"]:
     print("Download game data...")
     print("This may take a few seconds, sorry for the waiting.")
     print("0/4", end="\r")
-    download_branch = str(preferences["branch"])
+    download_branch = str(preferences["game data download"]["branch"])
+    download_repo = str(preferences["game data download"]["repository"])
+    download_org = str(preferences["game data download"]["org"])
 
     logger_sys.log_message("INFO: Downloading game yaml schemas files from github")
 
     # Download yaml schema files
     try:
         destination = program_dir + '/game/schemas'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
         fs.get(fs.ls("schemas/"), destination)
     except Exception as error:
         print(
@@ -151,7 +157,7 @@ if preferences["auto update"]:
     # Download data files
     try:
         destination = program_dir + '/game/data'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
         fs.get(fs.ls("data/"), destination)
     except Exception as error:
         print(
@@ -170,7 +176,7 @@ if preferences["auto update"]:
     # Download images .txt files
     try:
         destination = program_dir + '/game/imgs'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
         fs.get(fs.ls("imgs/"), destination)
     except Exception as error:
         print(
@@ -189,7 +195,7 @@ if preferences["auto update"]:
     # Download images .txt files
     try:
         destination = program_dir + '/game/scripts'
-        fs = fsspec.filesystem("github", org="Dungeons-Of-Kathallion", repo="Bane-Of-Wargs", branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
         fs.get(fs.ls("scripts/"), destination)
     except Exception as error:
         print(

--- a/source/main.py
+++ b/source/main.py
@@ -138,7 +138,7 @@ if preferences["auto update"]:
     # Download yaml schema files
     try:
         destination = program_dir + '/game/schemas'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
         fs.get(fs.ls("schemas/"), destination)
     except Exception as error:
         print(
@@ -157,7 +157,7 @@ if preferences["auto update"]:
     # Download data files
     try:
         destination = program_dir + '/game/data'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
         fs.get(fs.ls("data/"), destination)
     except Exception as error:
         print(
@@ -176,7 +176,7 @@ if preferences["auto update"]:
     # Download images .txt files
     try:
         destination = program_dir + '/game/imgs'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
         fs.get(fs.ls("imgs/"), destination)
     except Exception as error:
         print(
@@ -195,7 +195,7 @@ if preferences["auto update"]:
     # Download images .txt files
     try:
         destination = program_dir + '/game/scripts'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, branch=download_branch)
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
         fs.get(fs.ls("scripts/"), destination)
     except Exception as error:
         print(


### PR DESCRIPTION
# FEATURE

This PR add an useful new feature: being able to choose from which repository and from which branch/commit/tag name the game data should be downloaded at the beginning.

## Summary
This adds these new parameters to the preferences.yaml user game data file:
```yaml
"game data download": {
  "branch": "master", # the commit or branch/tag name
  "repository": "Bane-Of-Wargs", # the repository name
  "org": "Dungeons-Of-Kathallion" # the account/organization of the repository
}
```

## Usage examples
It would be useful for people who develop game data but on other branches/repositories

## Testing Done
Yes

## Performance Impact
N/A
