### PR TITLE
PROGRESS/FEATURE: Add In-Game Gameplay Guide Documentation Checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can also take the game to a next level by compiling it. Check the documentat
 
 Bane Of Wargs is a minimal game but you will have to install/updated some python modules.
 All required modules are in the `requirements.txt` file.
-[fade](https://pypi.org/project/fade/), [GitPython](https://pypi.org/project/GitPython/), [colorama](https://pypi.org/project/colorama/), [PyYaml](https://pypi.org/project/PyYAML/), [Yamale](https://pypi.org/project/yamale/), [Fsspec](https://filesystem-spec.readthedocs.io/en/latest/index.html), [AppDirs](https://pypi.org/project/appdirs/), [Requests](https://pypi.org/project/requests/).
+[fade](https://pypi.org/project/fade/), [GitPython](https://pypi.org/project/GitPython/), [colorama](https://pypi.org/project/colorama/), [PyYaml](https://pypi.org/project/PyYAML/), [Yamale](https://pypi.org/project/yamale/), [Fsspec](https://filesystem-spec.readthedocs.io/en/latest/index.html), [AppDirs](https://pypi.org/project/appdirs/), [Requests](https://pypi.org/project/requests/), [Rich]([rich](https://pypi.org/project/rich/)).
 
 ---
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python -m PyInstaller Bane-Of-Wargs.spec
+python -m PyInstaller Bane-Of-Wargs.spec --noconfirm

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -23,6 +23,7 @@ PyYaml
 Yamale
 Fsspec
 AppDirs
+rich
 ```
 
 You can also find them in the `requirements.txt` file, located in the root directory. You can also find a guide on how to install these packages in the [`docs/PLAYING.md`](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs/blob/master/docs/PLAYING.md#getting-required-moduleslibraries-installed--possibly-fix-issues) document.

--- a/docs/PLAYING.md
+++ b/docs/PLAYING.md
@@ -190,6 +190,7 @@ All of these modules/libraries are contained in the [requirements.txt](https://g
 * **[fsspec](https://filesystem-spec.readthedocs.io/en/latest/index.html)** // the module that makes downloading game data from the github repository and moving them to the game data folder possible.
 * **[appdirs](https://pypi.org/project/appdirs/)** // the module that make cross-platform game config and data storing in users directories possible
 * **[requests](https://pypi.org/project/requests/)** // the module that makes downloading game data from the github repository and moving them to the game data folder possible.
+* **[rich](https://pypi.org/project/rich/)** // the module that make displaying markdown files in terminal possible
 
 #### Installing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ yamale
 fsspec
 appdirs
 requests
+rich

--- a/source/data_handling.py
+++ b/source/data_handling.py
@@ -3,9 +3,13 @@ import logger_sys
 import check_yaml
 import colors
 import os
+import git
+import shutil
+import tempfile
 import yaml
 import time
 import text_handling
+import fsspec
 from colorama import Fore, Back, Style, init, deinit
 from colors import *
 
@@ -135,6 +139,38 @@ def load_game_data(which_type, what_plugin=None):
             check_yaml.examine(program_dir + "/plugins/" + what_plugin + "/mounts.yaml")
 
     return map, item, drinks, enemy, npcs, start_player, lists, zone, dialog, mission, mounts
+
+
+def fsspec_download(github_file, destination_point, download_org, download_repo, download_branch):
+    try:
+        destination = destination_point
+        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
+        fs.get(fs.ls(github_file), destination)
+    except Exception as error:
+        print(
+            COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" + COLOR_RESET_ALL +
+            " an error occurred when trying to download game data to '" +
+            destination + "'."
+        )
+        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'.")
+        logger_sys.log_message("DEBUG: " + str(error))
+        print(COLOR_YELLOW + str(error) + COLOR_RESET_ALL)
+        time.sleep(.5)
+
+
+def temporary_git_file_download(selected_file):
+    global file_text_data
+    # Create a temporary directory to after
+    # clone the repository and select the chosen
+    # file and export its data in a string
+
+    temporary_dir = tempfile.mkdtemp()
+    git.Repo.clone_from('https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs.wiki.git', temporary_dir, depth=1)
+
+    with open(temporary_dir + '/' + selected_file, 'r') as f:
+        file_text_data = f.read()
+
+    return file_text_data
 
 
 # deinitialize colorama

--- a/source/main.py
+++ b/source/main.py
@@ -473,7 +473,8 @@ while menu:
         text_handling.print_speech_text_effect(text, preferences)
 
         # Download documentation files
-        md_file = data_handling.temporary_git_file_download('Gameplay-Guide.md')
+        file = 'Gameplay-Guide.md'
+        md_file = data_handling.temporary_git_file_download(file)
 
         last_timer = time.time()
         time_for_process = round(last_timer - first_timer, 4)
@@ -494,7 +495,10 @@ while menu:
             wait = input()
         except Exception as error:
             error_occurred = True
-            print(COLOR_RED + COLOR_STYLE_BRIGHT + "ERROR: " + COLOR_RESET_ALL + COLOR_RED + f"file '{file}' does not exists" + COLOR_RESET_ALL)
+            print(
+                COLOR_RED + COLOR_STYLE_BRIGHT + "ERROR: " + COLOR_RESET_ALL +
+                COLOR_RED + f"file '{file}' does not exists" + COLOR_RESET_ALL
+            )
             logger_sys.log_message(f"ERROR: file '{file}' does not exists --> canceling gameplay guide markdown printing")
         os.system('clear')
     else:

--- a/source/main.py
+++ b/source/main.py
@@ -22,17 +22,23 @@ import readline
 import traceback
 import appdirs
 import shutil
-import fsspec
 import logger_sys
 from git import Repo
 from colorama import Fore, Back, Style, deinit, init
 from colors import *
 from sys import exit
+from rich.console import Console
+from rich.markdown import Markdown
 
 # initialize colorama
 init()
 
 os.system('clear')
+
+# defines console for the rich module
+# to work properly
+
+console = Console()
 
 # says you are not playing.
 play = 0
@@ -118,6 +124,7 @@ if not os.path.exists(program_dir):
     os.mkdir(program_dir + "/saves")
     os.mkdir(program_dir + "/game")
     os.mkdir(program_dir + "/logs")
+    os.mkdir(program_dir + "/docs")
 
 # Download game data from github master branch
 # and install them (auto-update)
@@ -135,82 +142,30 @@ if preferences["auto update"]:
 
     logger_sys.log_message("INFO: Downloading game yaml schemas files from github")
 
+    first_timer = time.time()
     # Download yaml schema files
-    try:
-        destination = program_dir + '/game/schemas'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
-        fs.get(fs.ls("schemas/"), destination)
-    except Exception as error:
-        print(
-            COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" + COLOR_RESET_ALL +
-            " an error occurred when trying to download game data to '" +
-            destination + "'."
-        )
-        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'.")
-        logger_sys.log_message("DEBUG: " + str(error))
-        print(COLOR_YELLOW + str(error) + COLOR_RESET_ALL)
-        time.sleep(.5)
-
+    data_handling.fsspec_download('schemas/', program_dir + '/game/schemas', download_branch, download_repo, download_org)
     print("1/4", end="\r")
 
     logger_sys.log_message("INFO: Downloading game data files from github")
     # Download data files
-    try:
-        destination = program_dir + '/game/data'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
-        fs.get(fs.ls("data/"), destination)
-    except Exception as error:
-        print(
-            COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" +
-            COLOR_RESET_ALL + " an error occurred when trying to download game data to '" +
-            destination + "'."
-            )
-        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'.")
-        logger_sys.log_message("DEBUG: " + str(error))
-        print(COLOR_YELLOW + str(error) + COLOR_RESET_ALL)
-        time.sleep(.5)
-
+    data_handling.fsspec_download('data/', program_dir + '/game/data', download_branch, download_repo, download_org)
     print("2/4", end="\r")
 
     logger_sys.log_message("INFO: Downloading game images .txt files from github")
     # Download images .txt files
-    try:
-        destination = program_dir + '/game/imgs'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
-        fs.get(fs.ls("imgs/"), destination)
-    except Exception as error:
-        print(
-            COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" +
-            COLOR_RESET_ALL + " an error occurred when trying to download game data to '" +
-            destination + "'."
-            )
-        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'.")
-        logger_sys.log_message("DEBUG: " + str(error))
-        print(COLOR_YELLOW + str(error) + COLOR_RESET_ALL)
-        time.sleep(.5)
-
+    data_handling.fsspec_download('imgs/', program_dir + '/game/imgs', download_branch, download_repo, download_org)
     print("3/4", end="\r")
 
     logger_sys.log_message("INFO: Downloading game scripts .py files from github")
-    # Download images .txt files
-    try:
-        destination = program_dir + '/game/scripts'
-        fs = fsspec.filesystem("github", org=download_org, repo=download_repo, sha=download_branch)
-        fs.get(fs.ls("scripts/"), destination)
-    except Exception as error:
-        print(
-            COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" +
-            COLOR_RESET_ALL + " an error occurred when trying to download game data to '" +
-            destination + "'."
-            )
-        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'.")
-        logger_sys.log_message("DEBUG: " + str(error))
-        print(COLOR_YELLOW + str(error) + COLOR_RESET_ALL)
-        time.sleep(.5)
+    # Download scripts .py files
+    data_handling.fsspec_download('scripts/', program_dir + '/game/scripts', download_branch, download_repo, download_org)
 
     print("4/4")
     print("Done")
-    logger_sys.log_message("INFO: Process of downloading game data to update it completed")
+    last_timer = time.time()
+    process_time = round(last_timer - first_timer, 4)
+    logger_sys.log_message(f"INFO: Process of downloading game data to update it completed in {process_time} seconds")
 
 
 # main menu start
@@ -236,7 +191,7 @@ while menu:
     os.system('clear')
     print_title()
 
-    options = ['Play Game', 'Manage Saves', 'Preferences', 'Check Update', 'Quit']
+    options = ['Play Game', 'Manage Saves', 'Preferences', 'Check Update', 'Gameplay Guide', 'Quit']
     choice = term_menu.show_menu(options)
     os.system('clear')
 
@@ -511,6 +466,37 @@ while menu:
             time.sleep(5)
         text = "Finished Updating."
         text_handling.print_speech_text_effect(text, preferences)
+    elif choice == 'Gameplay Guide':
+        first_timer = time.time()
+        logger_sys.log_message("INFO: Downloading game documentation")
+        text = "Downloading game documentation..."
+        text_handling.print_speech_text_effect(text, preferences)
+
+        # Download documentation files
+        md_file = data_handling.temporary_git_file_download('Gameplay-Guide.md')
+
+        last_timer = time.time()
+        time_for_process = round(last_timer - first_timer, 4)
+        logger_sys.log_message(f"INFO: Finished game documentation downloading process in {time_for_process} seconds")
+        text = "Finished downloading process..."
+        text_handling.print_speech_text_effect(text, preferences)
+
+        # Actually display the markdown file
+        # to the terminal with 'rich' module
+        error_occurred = False
+
+        os.system('clear')
+
+        try:
+            md_text = Markdown(md_file)
+            console.print(md_text)
+
+            wait = input()
+        except Exception as error:
+            error_occurred = True
+            print(COLOR_RED + COLOR_STYLE_BRIGHT + "ERROR: " + COLOR_RESET_ALL + COLOR_RED + f"file '{file}' does not exists" + COLOR_RESET_ALL)
+            logger_sys.log_message(f"ERROR: file '{file}' does not exists --> canceling gameplay guide markdown printing")
+        os.system('clear')
     else:
         os.system('clear')
         exit(1)


### PR DESCRIPTION
# FEATURE

This PR adds a new option in the main menu, to checkout the github wiki page called 'Gameplay Guide' in the terminal. Also removes repeating actions when downloading game data at start, by creating a function in the `data_handling.py` script. It also add some more/better log information.

## Usage examples
Useful for new players and future contributors.

## Testing Done
Everything tested by now.

## Performance Impact
Some, because of the internet download.
