### PR TITLE
PROGRESS: Add Ability For Map Zones To Define Which Enemy List To Spawn At Night

### DIFF
--- a/data/map.yaml
+++ b/data/map.yaml
@@ -36823,6 +36823,7 @@ point15519:
   y: -56
 point1552:
   blocked:
+  - South
   - East
   map zone: Forlindon Woods
   x: -60

--- a/data/zone.yaml
+++ b/data/zone.yaml
@@ -851,6 +851,7 @@ Forlindon Woods:
   name: "Forlindon Woods"
   description: "A small and quite forest where you find a small village, living apart of the other great cities."
   type: woods
+  enemy spawning: warg raids
   map:
     map full: |
       x__________x

--- a/schemas/zones_badlands butte.yaml
+++ b/schemas/zones_badlands butte.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_badlands canyon.yaml
+++ b/schemas/zones_badlands canyon.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_badlands hills.yaml
+++ b/schemas/zones_badlands hills.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_badlands landforms.yaml
+++ b/schemas/zones_badlands landforms.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_badlands plateaus.yaml
+++ b/schemas/zones_badlands plateaus.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_badlands valleys.yaml
+++ b/schemas/zones_badlands valleys.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_badlands.yaml
+++ b/schemas/zones_badlands.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_beach.yaml
+++ b/schemas/zones_beach.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_black rocky canyons.yaml
+++ b/schemas/zones_black rocky canyons.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_black rocky mountains.yaml
+++ b/schemas/zones_black rocky mountains.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_colors.yaml
+++ b/schemas/zones_colors.yaml
@@ -30,7 +30,7 @@ forge: 28
 blacksmith: 29
 stable: 30
 church: 31
-castles: 32
+castle: 32
 lake: 33
 sea: 34
 swamps: 35

--- a/schemas/zones_dark woods.yaml
+++ b/schemas/zones_dark woods.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_desert canyons.yaml
+++ b/schemas/zones_desert canyons.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_desert hills.yaml
+++ b/schemas/zones_desert hills.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_desert valleys.yaml
+++ b/schemas/zones_desert valleys.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_desert.yaml
+++ b/schemas/zones_desert.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_fields.yaml
+++ b/schemas/zones_fields.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_flatlands.yaml
+++ b/schemas/zones_flatlands.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_high mountains.yaml
+++ b/schemas/zones_high mountains.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_hills.yaml
+++ b/schemas/zones_hills.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_lake.yaml
+++ b/schemas/zones_lake.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_low mountains.yaml
+++ b/schemas/zones_low mountains.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_mountains.yaml
+++ b/schemas/zones_mountains.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_plains canyon.yaml
+++ b/schemas/zones_plains canyon.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_plains.yaml
+++ b/schemas/zones_plains.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_rocky canyons.yaml
+++ b/schemas/zones_rocky canyons.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_sea.yaml
+++ b/schemas/zones_sea.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_swamps.yaml
+++ b/schemas/zones_swamps.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_valleys.yaml
+++ b/schemas/zones_valleys.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/schemas/zones_woods.yaml
+++ b/schemas/zones_woods.yaml
@@ -4,3 +4,4 @@ type: str()
 map:
   map full: str()
   map raw: str(required=False)
+enemy spawning: str(required=False)

--- a/source/main.py
+++ b/source/main.py
@@ -1381,10 +1381,11 @@ def run(play):
             )
 
         elif (
-            day_time == COLOR_RED + COLOR_STYLE_BRIGHT + "NIGHT" + COLOR_RESET_ALL
+            day_time == COLOR_RED + COLOR_STYLE_BRIGHT + "☾ NIGHT" + COLOR_RESET_ALL
             and round(random.uniform(.20, .80), 3) > .7 and zone[map_zone]["type"] != "hostel"
             and zone[map_zone]["type"] != "stable" and zone[map_zone]["type"] != "village"
             and zone[map_zone]["type"] != "blacksmith" and zone[map_zone]["type"] != "forge"
+            and zone[map_zone]["type"] != "castle" and zone[map_zone]["type"] != "church"
         ):
             logger_sys.log_message("INFO: Checking if it's night time")
             logger_sys.log_message(
@@ -1392,8 +1393,12 @@ def run(play):
             )
             logger_sys.log_message("INFO: Calculating random chance of enemy spawning")
             logger_sys.log_message("INFO: Spawning enemies")
+            if "enemy spawning" in list(zone[map_zone]):
+                enemy_list_to_spawn = lists[str(zone[map_zone]["enemy spawning"])]
+            else:
+                enemy_list_to_spawn = lists["generic"]
             enemy_handling.spawn_enemy(
-                map_location, lists['generic'], round(random.uniform(1, 5)), enemy,
+                map_location, enemy_list_to_spawn, round(random.uniform(1, 5)), enemy,
                 item, lists, start_player, map, player,
                 preferences, drinks, npcs, zone, mounts, mission, dialog
             )
@@ -2247,7 +2252,7 @@ def run(play):
                 zone_handling.interaction_forge(map_zone, zone, player, item)
             else:
                 logger_sys.log_message(f"INFO: Map zone '{map_zone}' cannot have interactions")
-                print(COLOR_YELLOW + "You cannot find any near hostel, stable, blacksmith, forge or church." + COLOR_RESET_ALL)
+                print(COLOR_YELLOW + "You cannot find any near hostel, stable, blacksmith, forge, church or castle." + COLOR_RESET_ALL)
                 time.sleep(1.5)
             continued_command = True
         elif command.lower().startswith('y'):

--- a/source/main.py
+++ b/source/main.py
@@ -2252,7 +2252,10 @@ def run(play):
                 zone_handling.interaction_forge(map_zone, zone, player, item)
             else:
                 logger_sys.log_message(f"INFO: Map zone '{map_zone}' cannot have interactions")
-                print(COLOR_YELLOW + "You cannot find any near hostel, stable, blacksmith, forge, church or castle." + COLOR_RESET_ALL)
+                print(
+                    COLOR_YELLOW + "You cannot find any near hostel, stable, blacksmith, forge, church or castle." +
+                    COLOR_RESET_ALL
+                )
                 time.sleep(1.5)
             continued_command = True
         elif command.lower().startswith('y'):


### PR DESCRIPTION
# FEATURE/PROGRESS

This PR adds a new attributes for map zone: a `enemy spawning` attribute where you define the enemy lists that spawns at night. If this attributes isn't specified, it's the `generic` list that'll be spawned.
