### PR TITLE
FEATURE-PROGRESS-CONTENT: Multiple Coordinates Moving

### DIFF
--- a/data/map.yaml
+++ b/data/map.yaml
@@ -2222,6 +2222,8 @@ point1033:
   blocked:
   - South
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -63
   y: 56
@@ -2287,7 +2289,7 @@ point10339:
   y: -16
 point1034:
   blocked:
-  - None
+  - South-West
   map zone: Forlindon Woods
   x: -62
   y: 56
@@ -2421,6 +2423,8 @@ point10359:
 point1036:
   blocked:
   - East
+  - North-East
+  - North-West
   map zone: Forlindon Woods
   x: -60
   y: 56
@@ -10887,6 +10891,7 @@ point11629:
 point1163:
   blocked:
   - West
+  - South-West
   map zone: Forlindon Woods
   x: -62
   y: 55
@@ -11019,6 +11024,8 @@ point11649:
 point1165:
   blocked:
   - East
+  - North-East
+  - North-West
   map zone: Forlindon Woods
   x: -60
   y: 55
@@ -19485,6 +19492,8 @@ point12919:
 point1292:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -62
   y: 54
@@ -20690,6 +20699,9 @@ point131:
   blocked:
   - West
   - East
+  - South-West
+  - North-West
+  - North-East
   map zone: Forlindon Woods
   x: -62
   y: 63
@@ -28094,6 +28106,8 @@ point14209:
 point1421:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -62
   y: 53
@@ -28226,6 +28240,8 @@ point14229:
 point1423:
   blocked:
   - East
+  - North-East
+  - North-West
   map zone: Forlindon Woods
   x: -60
   y: 53
@@ -36692,6 +36708,8 @@ point155:
 point1550:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -62
   y: 52
@@ -36757,7 +36775,7 @@ point15509:
   y: -56
 point1551:
   blocked:
-  - None
+  - South-East
   map zone: Forlindon Woods
   x: -61
   y: 52
@@ -36825,6 +36843,8 @@ point1552:
   blocked:
   - South
   - East
+  - North-West
+  - North-East
   map zone: Forlindon Woods
   x: -60
   y: 52
@@ -44379,6 +44399,8 @@ point1678:
 point1679:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -62
   y: 51
@@ -44391,6 +44413,7 @@ point168:
 point1680:
   blocked:
   - East
+  - South-East
   map zone: Forlindon Woods
   x: -61
   y: 51
@@ -45244,6 +45267,9 @@ point1808:
   blocked:
   - South
   - West
+  - South-West
+  - South-East
+  - North-West
   map zone: Forlindon Woods
   x: -62
   y: 50
@@ -45251,6 +45277,8 @@ point1809:
   blocked:
   - South
   - East
+  - South-West
+  - South-East
   map zone: Forlindon Woods
   x: -61
   y: 50
@@ -46519,6 +46547,10 @@ point2:
   - West
   - East
   - North
+  - South-West
+  - South-East
+  - North-West
+  - North-East
   map zone: Forlindon Woods
   x: -62
   y: 64
@@ -50527,6 +50559,8 @@ point26:
 point260:
   blocked:
   - West
+  - North-West
+  - North-East
   map zone: Forlindon Woods
   x: -62
   y: 62
@@ -50593,6 +50627,7 @@ point2609:
 point261:
   blocked:
   - North
+  - North-East
   map zone: Forlindon Woods
   x: -61
   y: 62
@@ -50659,6 +50694,8 @@ point2619:
 point262:
   blocked:
   - North
+  - North-East
+  - North-West
   map zone: Forlindon Woods
   x: -60
   y: 62
@@ -50726,6 +50763,9 @@ point263:
   blocked:
   - North
   - East
+  - North-East
+  - North-West
+  - South-East
   map zone: Forlindon Woods
   x: -59
   y: 62
@@ -59055,6 +59095,8 @@ point388:
   blocked:
   - West
   - North
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -63
   y: 61
@@ -59120,7 +59162,7 @@ point3889:
   y: 34
 point389:
   blocked:
-  - None
+  - North-West
   map zone: Forlindon Woods
   x: -62
   y: 61
@@ -59258,7 +59300,7 @@ point3909:
   y: 34
 point391:
   blocked:
-  - None
+  - South-East
   map zone: Forlindon Woods
   x: -60
   y: 61
@@ -59326,6 +59368,8 @@ point392:
   blocked:
   - North
   - East
+  - North-East
+  - South-East
   map zone: Forlindon Woods
   x: -59
   y: 61
@@ -67660,6 +67704,8 @@ point5169:
 point517:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -63
   y: 60
@@ -67864,6 +67910,7 @@ point52:
 point520:
   blocked:
   - East
+  - South-East
   map zone: Forlindon Woods
   x: -60
   y: 60
@@ -76258,6 +76305,8 @@ point6459:
 point646:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -63
   y: 59
@@ -76456,6 +76505,7 @@ point6489:
 point649:
   blocked:
   - East
+  - North-East
   map zone: Forlindon Woods
   x: -60
   y: 59
@@ -84856,6 +84906,8 @@ point7749:
 point775:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -63
   y: 58
@@ -85054,6 +85106,8 @@ point7779:
 point778:
   blocked:
   - East
+  - North-East
+  - North-West
   map zone: Forlindon Woods
   x: -60
   y: 58
@@ -93460,6 +93514,8 @@ point9039:
 point904:
   blocked:
   - West
+  - South-West
+  - North-West
   map zone: Forlindon Woods
   x: -63
   y: 57
@@ -93658,6 +93714,8 @@ point9069:
 point907:
   blocked:
   - East
+  - North-East
+  - North-West
   map zone: Forlindon Woods
   x: -60
   y: 57

--- a/data/zone.yaml
+++ b/data/zone.yaml
@@ -124,7 +124,7 @@ Cocorico Village:
   name: "Cocorico Village"
   description: "The village in the Stall Fields. It offers tranquility and safeness."
   type: village
-  location: 0
+  location: 2334
   news:
   - "Hey! Did you ever heard about tamed Wargs? Seems crazy right?"
   - "You should checkout the hostel in the village! They sell items for great prices!"
@@ -161,7 +161,7 @@ Ayar Town:
   name: "Ayar Town"
   description: "A small village located in the Forlindon Woods. It's a quiet place to live."
   type: village
-  location: 0
+  location: 647
   news:
   - "Hey! Have you ever heard about the Goro Mounts? Apparently our mayor have contacts with a dwarf colony there."
   - "..."
@@ -194,7 +194,7 @@ New Hyru:
   name: "New Hyru"
   description: "Located in the Californ Woods, it is a quit dangerous place, but also welcoming if you're careful."
   type: village
-  location: 0
+  location: 4777
   news:
   - "..."
   map:
@@ -226,7 +226,7 @@ Los Gerudos:
   name: "New Hyru"
   description: "Located in the Gerud Valleys, Los Gerudos is a great town for adventurers that are willing to train and challenge themselves."
   type: village
-  location: 0
+  location: 673
   news:
   - "..."
   map:
@@ -258,7 +258,7 @@ Los Gerudos Hostel:
   name: "Los Gerudo Hostel"
   description: "The hostel of the town of Los Gerudos. It was originally a Yrch outpost, but a century ago, it has been taken by an adventurer called Cromha MCcloud... From there, the town has been built around this hostel."
   type: hostel
-  location: 0
+  location: 6990
   news:
   - "..."
   map:
@@ -305,7 +305,7 @@ Kathal Horses:
   name: "Kathal Horses"
   description: "A great place where you can adopt horses mounts, train them or sell them. You can also find good quality horse equipment here."
   type: stable
-  location: 0
+  location: 6473
   cost value: 1.2
   training gold: 24
   deposit gold: .23
@@ -352,7 +352,7 @@ Woodstack Hostel:
   type: hostel
   cost value: .9
   sleep gold: 7
-  location: 0
+  location: 2075
   description: "The Woodstack Hostel is a nice place to be and you can find amazing people."
   news:
   - "Hey! Did you ever heard about tamed Wargs? Seems crazy right?"
@@ -394,7 +394,7 @@ Seaside Hostels:
   type: hostel
   cost value: 1.8
   sleep gold: 21
-  location: 0
+  location: 2326
   description: "The Seaside Hostels are a company of hostels that are settled in the west coast of the Stall Island. There are great hostels near the beach."
   news:
   - "..."
@@ -442,7 +442,7 @@ Pickaxe Forge:
   name: "Pickaxe Forge"
   type: forge
   cost value: 1.15
-  location: 0
+  location: 4778
   description: "At the Pickaxe Forge you'll be able to buy any metal at low prices for its high quality!"
   news:
   - "Hey! Did you ever heard about tamed Wargs? Seems crazy right?"
@@ -479,7 +479,7 @@ Gerud Forges:
   name: "Gerud Forges"
   type: forge
   cost value: 1.25
-  location: 0
+  location: 7764
   description: "One of the most known forge in the eastern Stall Island. Huge prices but great quality."
   news:
   - "..."
@@ -520,7 +520,7 @@ James Blacksmith:
   name: "James Blacksmith"
   type: blacksmith
   cost value: 1
-  location: 0
+  location: 2463
   description: "Welcome to James Blacksmith! You can here sell metals to make gold, but metals and order many type of swords!"
   news:
   - "Hey! Did you ever heard about tamed Wargs? Seems crazy right?"
@@ -581,7 +581,7 @@ Gerud Armorer:
   name: "Gerud Armorer"
   type: blacksmith
   cost value: 1.7
-  location: 0
+  location: 7508
   description: "One of the most well know blacksmith in the eastern Stall Island. They sell extreme quality materials here."
   news:
   - "..."
@@ -705,7 +705,7 @@ Clarc Warg Stable:
   name: "Clarc Stable"
   type: stable
   cost value: .7
-  location: 0
+  location: 5551
   training gold: 18
   deposit gold: .15
   description: "Here, you'll be able to buy pre-tamed Wargs, train them and make sure they have a great live as a human mount and not an Orc mount."

--- a/source/main.py
+++ b/source/main.py
@@ -1234,9 +1234,13 @@ def run(play):
         else:
             print("                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "P: " + COLOR_RESET_ALL + "Pause game")
         if "South-East" not in blocked_locations:
-            print("Can go South-East ⬊" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Backup player save")
+            print(
+                "Can go South-East ⬊" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Backup player save"
+            )
         else:
-            print("                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Backup player save")
+            print(
+                "                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Backup player save"
+            )
         if "South-East" not in blocked_locations:
             print("Can go South-West ⬋" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Q: " + COLOR_RESET_ALL + "Quit & save game")
         else:
@@ -1624,7 +1628,9 @@ def run(play):
                 logger_sys.log_message(f"INFO: Refusing access to north-east: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
             elif "key" in map["point" + str(next_point)]:
-                logger_sys.log_message(f"INFO: Checking if a key is required for going north-east at map point 'point{next_point}'")
+                logger_sys.log_message(
+                    f"INFO: Checking if a key is required for going north-east at map point 'point{next_point}'"
+                )
                 check_for_key("north-east")
             else:
                 logger_sys.log_message(f"INFO: Moving player north-east to map point 'point{next_point}': successful checks")
@@ -1639,7 +1645,9 @@ def run(play):
                 logger_sys.log_message(f"INFO: Refusing access to north-west: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
             elif "key" in map["point" + str(next_point)]:
-                logger_sys.log_message(f"INFO: Checking if a key is required for going north-west at map point 'point{next_point}'")
+                logger_sys.log_message(
+                    f"INFO: Checking if a key is required for going north-west at map point 'point{next_point}'"
+                )
                 check_for_key("north-west")
             else:
                 logger_sys.log_message(f"INFO: Moving player north-west to map point 'point{next_point}': successful checks")
@@ -1654,7 +1662,9 @@ def run(play):
                 logger_sys.log_message(f"INFO: Refusing access to south-east: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
             elif "key" in map["point" + str(next_point)]:
-                logger_sys.log_message(f"INFO: Checking if a key is required for going south-east at map point 'point{next_point}'")
+                logger_sys.log_message(
+                    f"INFO: Checking if a key is required for going south-east at map point 'point{next_point}'"
+                )
                 check_for_key("south-east")
             else:
                 logger_sys.log_message(f"INFO: Moving player south-east to map point 'point{next_point}': successful checks")
@@ -1669,7 +1679,9 @@ def run(play):
                 logger_sys.log_message(f"INFO: Refusing access to south-west: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
             elif "key" in map["point" + str(next_point)]:
-                logger_sys.log_message(f"INFO: Checking if a key is required for going south-west at map point 'point{next_point}'")
+                logger_sys.log_message(
+                    f"INFO: Checking if a key is required for going south-west at map point 'point{next_point}'"
+                )
                 check_for_key("south-west")
             else:
                 logger_sys.log_message(f"INFO: Moving player south-west to map point 'point{next_point}': successful checks")

--- a/source/main.py
+++ b/source/main.py
@@ -1576,6 +1576,66 @@ def run(play):
             print(COLOR_YELLOW + "Rather than saying Go <direction>, simply say <direction>." + COLOR_RESET_ALL)
             time.sleep(1.5)
             continued_command = True
+        elif command.lower().startswith('ne'):
+            logger_sys.log_message(f"INFO: Checking if player can go north-east from map point 'point{map_location}'")
+            next_point = search(player["x"] + 1, player["y"] + 1)
+            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+                print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
+                logger_sys.log_message(f"INFO: Refusing access to north-east: access blocked to map point 'point{next_point}'")
+                time.sleep(1)
+            elif "key" in map["point" + str(next_point)]:
+                logger_sys.log_message(f"INFO: Checking if a key is required for going north-east at map point 'point{next_point}'")
+                check_for_key("north-east")
+            else:
+                logger_sys.log_message(f"INFO: Moving player north-east to map point 'point{next_point}': successful checks")
+                player["y"] += 1
+                player["x"] += 1
+            continued_command = True
+        elif command.lower().startswith('nw'):
+            logger_sys.log_message(f"INFO: Checking if player can go north-west from map point 'point{map_location}'")
+            next_point = search(player["x"] - 1, player["y"] + 1)
+            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+                print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
+                logger_sys.log_message(f"INFO: Refusing access to north-west: access blocked to map point 'point{next_point}'")
+                time.sleep(1)
+            elif "key" in map["point" + str(next_point)]:
+                logger_sys.log_message(f"INFO: Checking if a key is required for going north-west at map point 'point{next_point}'")
+                check_for_key("north-west")
+            else:
+                logger_sys.log_message(f"INFO: Moving player north-west to map point 'point{next_point}': successful checks")
+                player["y"] += 1
+                player["x"] -= 1
+            continued_command = True
+        elif command.lower().startswith('se'):
+            logger_sys.log_message(f"INFO: Checking if player can go south-east from map point 'point{map_location}'")
+            next_point = search(player["x"] + 1, player["y"] - 1)
+            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+                print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
+                logger_sys.log_message(f"INFO: Refusing access to south-east: access blocked to map point 'point{next_point}'")
+                time.sleep(1)
+            elif "key" in map["point" + str(next_point)]:
+                logger_sys.log_message(f"INFO: Checking if a key is required for going south-east at map point 'point{next_point}'")
+                check_for_key("south-east")
+            else:
+                logger_sys.log_message(f"INFO: Moving player south-east to map point 'point{next_point}': successful checks")
+                player["y"] -= 1
+                player["x"] += 1
+            continued_command = True
+        elif command.lower().startswith('sw'):
+            logger_sys.log_message(f"INFO: Checking if player can go south-west from map point 'point{map_location}'")
+            next_point = search(player["x"] - 1, player["y"] - 1)
+            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+                print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
+                logger_sys.log_message(f"INFO: Refusing access to south-west: access blocked to map point 'point{next_point}'")
+                time.sleep(1)
+            elif "key" in map["point" + str(next_point)]:
+                logger_sys.log_message(f"INFO: Checking if a key is required for going south-west at map point 'point{next_point}'")
+                check_for_key("south-west")
+            else:
+                logger_sys.log_message(f"INFO: Moving player south-west to map point 'point{next_point}': successful checks")
+                player["y"] -= 1
+                player["x"] -= 1
+            continued_command = True
         elif command.lower().startswith('n'):
             logger_sys.log_message(f"INFO: Checking if player can go north from map point 'point{map_location}'")
             next_point = search(player["x"], player["y"] + 1)

--- a/source/main.py
+++ b/source/main.py
@@ -609,33 +609,53 @@ def remove_gold(amount):
 
 def check_for_key(direction):
     logger_sys.log_message("INFO: Checking for key at every next locations possible")
-    map_point_count = int(len(list(map)))
+    map_point_count = len(list(map))
     if direction == "north":
         for i in range(0, map_point_count):
             point_i = map["point" + str(i)]
             point_x, point_y = point_i["x"], point_i["y"] - 1
-            # print(i, point_x, point_y, player)
             if point_x == player["x"] and point_y == player["y"]:
                 future_map_location = i
     elif direction == "south":
         for i in range(0, map_point_count):
             point_i = map["point" + str(i)]
             point_x, point_y = point_i["x"], point_i["y"] + 1
-            # print(i, point_x, point_y, player)
             if point_x == player["x"] and point_y == player["y"]:
                 future_map_location = i
     elif direction == "east":
         for i in range(0, map_point_count):
             point_i = map["point" + str(i)]
             point_x, point_y = point_i["x"] - 1, point_i["y"]
-            # print(i, point_x, point_y, player)
             if point_x == player["x"] and point_y == player["y"]:
                 future_map_location = i
     elif direction == "west":
         for i in range(0, map_point_count):
             point_i = map["point" + str(i)]
             point_x, point_y = point_i["x"] + 1, point_i["y"]
-            # print(i, point_x, point_y, player)
+            if point_x == player["x"] and point_y == player["y"]:
+                future_map_location = i
+    elif direction == "north-east":
+        for i in range(0, map_point_count):
+            point_i = map["point" + str(i)]
+            point_x, point_y = point_i["x"] + 1, point_i["y"] + 1
+            if point_x == player["x"] and point_y == player["y"]:
+                future_map_location = i
+    elif direction == "north-west":
+        for i in range(0, map_point_count):
+            point_i = map["point" + str(i)]
+            point_x, point_y = point_i["x"] - 1, point_i["y"] + 1
+            if point_x == player["x"] and point_y == player["y"]:
+                future_map_location = i
+    elif direction == "south-east":
+        for i in range(0, map_point_count):
+            point_i = map["point" + str(i)]
+            point_x, point_y = point_i["x"] + 1, point_i["y"] - 1
+            if point_x == player["x"] and point_y == player["y"]:
+                future_map_location = i
+    elif direction == "south-west":
+        for i in range(0, map_point_count):
+            point_i = map["point" + str(i)]
+            point_x, point_y = point_i["x"] - 1, point_i["y"] - 1
             if point_x == player["x"] and point_y == player["y"]:
                 future_map_location = i
     if "key" in map["point" + str(future_map_location)]:
@@ -1579,7 +1599,7 @@ def run(play):
         elif command.lower().startswith('ne'):
             logger_sys.log_message(f"INFO: Checking if player can go north-east from map point 'point{map_location}'")
             next_point = search(player["x"] + 1, player["y"] + 1)
-            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+            if "North-East" in map["point" + str(map_location)]["blocked"] or next_point is None:
                 print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
                 logger_sys.log_message(f"INFO: Refusing access to north-east: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
@@ -1594,7 +1614,7 @@ def run(play):
         elif command.lower().startswith('nw'):
             logger_sys.log_message(f"INFO: Checking if player can go north-west from map point 'point{map_location}'")
             next_point = search(player["x"] - 1, player["y"] + 1)
-            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+            if "North-West" in map["point" + str(map_location)]["blocked"] or next_point is None:
                 print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
                 logger_sys.log_message(f"INFO: Refusing access to north-west: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
@@ -1609,7 +1629,7 @@ def run(play):
         elif command.lower().startswith('se'):
             logger_sys.log_message(f"INFO: Checking if player can go south-east from map point 'point{map_location}'")
             next_point = search(player["x"] + 1, player["y"] - 1)
-            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+            if "South-East" in map["point" + str(map_location)]["blocked"] or next_point is None:
                 print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
                 logger_sys.log_message(f"INFO: Refusing access to south-east: access blocked to map point 'point{next_point}'")
                 time.sleep(1)
@@ -1624,7 +1644,7 @@ def run(play):
         elif command.lower().startswith('sw'):
             logger_sys.log_message(f"INFO: Checking if player can go south-west from map point 'point{map_location}'")
             next_point = search(player["x"] - 1, player["y"] - 1)
-            if "North" in map["point" + str(map_location)]["blocked"] or next_point is None:
+            if "South-West" in map["point" + str(map_location)]["blocked"] or next_point is None:
                 print(COLOR_YELLOW + "You cannot go that way." + COLOR_RESET_ALL)
                 logger_sys.log_message(f"INFO: Refusing access to south-west: access blocked to map point 'point{next_point}'")
                 time.sleep(1)

--- a/source/main.py
+++ b/source/main.py
@@ -784,6 +784,7 @@ def run(play):
             COLOR_RESET_ALL
         )
         print(COLOR_BLUE + COLOR_STYLE_BRIGHT + "Z: " + COLOR_RESET_ALL + "Access to nearest hostel, stable or church.")
+        print(COLOR_BLUE + COLOR_STYLE_BRIGHT + "P: " + COLOR_RESET_ALL + "Pause game")
         print(COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Save game")
         print(COLOR_BLUE + COLOR_STYLE_BRIGHT + "Q: " + COLOR_RESET_ALL + "Quit & save game")
         print(" ")
@@ -1201,28 +1202,45 @@ def run(play):
 
         print("DIRECTIONS: " + "          ACTIONS:")
 
-        if "North" not in map["point" + str(map_location)]["blocked"]:
-            print("You can go North ▲" + "    " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "I: " + COLOR_RESET_ALL + "View items")
+        blocked_locations = map["point" + str(map_location)]["blocked"]
+        if "North" not in blocked_locations:
+            print("Can go North ⬆    " + "    " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "I: " + COLOR_RESET_ALL + "View items")
         else:
             print("                  " + "    " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "I: " + COLOR_RESET_ALL + "View items")
-        if "South" not in map["point" + str(map_location)]["blocked"]:
-            print("You can go South ▼" + "    " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "D: " + COLOR_RESET_ALL + "Check your diary")
+        if "South" not in blocked_locations:
+            print("Can go South ⬇    " + "    " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "D: " + COLOR_RESET_ALL + "Check your diary")
         else:
             print("                  " + "    " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "D: " + COLOR_RESET_ALL + "Check your diary")
-        if "East" not in map["point" + str(map_location)]["blocked"]:
+        if "East" not in blocked_locations:
             print(
-                "You can go East ►" + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Z: " +
-                COLOR_RESET_ALL + "Interact with zone (hostel...)"
+                "Can go East ➡    " + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Z: " +
+                COLOR_RESET_ALL + "Interact with zone"
             )
         else:
             print(
                 "                 " + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT +
-                "Z: " + COLOR_RESET_ALL + "Interact with zone (hostel...)"
+                "Z: " + COLOR_RESET_ALL + "Interact with zone"
             )
-        if "West" not in map["point" + str(map_location)]["blocked"]:
-            print("You can go West ◄" + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Q: " + COLOR_RESET_ALL + "Quit & save")
+        if "West" not in blocked_locations:
+            print("Can go West ⬅    " + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Y: " + COLOR_RESET_ALL + "View owned mounts")
         else:
-            print("                 " + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Q: " + COLOR_RESET_ALL + "Quit & save")
+            print("                 " + "     " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Y: " + COLOR_RESET_ALL + "View owned mounts")
+        if "North-East" not in blocked_locations:
+            print("Can go North-East ⬈" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "M: " + COLOR_RESET_ALL + "Examine world map")
+        else:
+            print("                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "M: " + COLOR_RESET_ALL + "Examine world map")
+        if "North-West" not in blocked_locations:
+            print("Can go North-West ⬉" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "P: " + COLOR_RESET_ALL + "Pause game")
+        else:
+            print("                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "P: " + COLOR_RESET_ALL + "Pause game")
+        if "South-East" not in blocked_locations:
+            print("Can go South-East ⬊" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Backup player save")
+        else:
+            print("                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "K: " + COLOR_RESET_ALL + "Backup player save")
+        if "South-East" not in blocked_locations:
+            print("Can go South-West ⬋" + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Q: " + COLOR_RESET_ALL + "Quit & save game")
+        else:
+            print("                   " + "   " + COLOR_BLUE + COLOR_STYLE_BRIGHT + "Q: " + COLOR_RESET_ALL + "Quit & save game")
 
         text = '='
         text_handling.print_separator(text)
@@ -1577,6 +1595,8 @@ def run(play):
         logger_sys.log_message(f"INFO: Player ran command '{command}'")
         logger_sys.log_message(f"INFO: Checking if a ground item is present at map point 'point{map_location}'")
         continued_command = False
+        global pause_time
+        pause_time = 0  # required variable
         if "item" in map["point" + str(map_location)] and command in map["point" + str(map_location)]["item"]:
             logger_sys.log_message(f"INFO: Found item '{command}' at map point 'point{map_location}'")
             if command in player["inventory"] and item[command]["type"] == "Utility":
@@ -2635,6 +2655,15 @@ def run(play):
                 f.write(dumped)
                 logger_sys.log_message(f"INFO: Dumping player preferences to file '" + program_dir + "/preferences.yaml'")
             continued_command = True
+        elif command.lower().startswith('p'):
+            logger_sys.log_message("INFO: Pausing game")
+            print("Press enter to unpause game...")
+            pause_start = time.time()
+            input()
+            pause_end = time.time()
+            pause_time = pause_end - pause_start
+            logger_sys.log_message(f"INFO: Finished pausing game --> game pause have lasted {pause_time} seconds")
+            continued_command = True
         elif command.lower().startswith('q'):
             logger_sys.log_message("INFO: Closing & Saving game")
             text_handling.print_separator('=')
@@ -2742,15 +2771,15 @@ def run(play):
 
         # calculate elapsed time
         elapsed_time = end_time - start_time
-        elapsed_time = round(elapsed_time, 2)
+        elapsed_time = round(elapsed_time, 2) - pause_time
         logger_sys.log_message(f"INFO: Getting elapsed time: '{elapsed_time}'")
 
-        game_elapsed_time = time_handling.return_game_day_from_seconds(elapsed_time, time_elapsing_coefficient)
+        game_elapsed_time = time_handling.return_game_day_from_seconds(elapsed_time - pause_time, time_elapsing_coefficient)
         game_elapsed_time = round(game_elapsed_time, 2)
         logger_sys.log_message(f"INFO: Getting elapsed time in game days: '{game_elapsed_time}'")
 
-        player["elapsed time seconds"] = float(elapsed_time) + float(player["elapsed time seconds"])
-        player["elapsed time game days"] = game_elapsed_time + player["elapsed time game days"]
+        player["elapsed time seconds"] += elapsed_time
+        player["elapsed time game days"] += game_elapsed_time
 
 
 if play == 1:


### PR DESCRIPTION
# FEATURE/PROGRESS/CONTENT

This PR addresses the bug/feature described in issue game goal "Make possible going both x and y coordinates when moving (for example NW command that does `x, y = x - 1, y + 1`)"

## Summary
- This PR adds five new main commands:
  - NE <move x +1, y+1>
  - NW <move x -1, y+1>
  - SE <move x +1, y-1>
  - SW <move x -1, y-1>
  - P <pause game (stop day calculation)>
- And finally update very zone `location` key

This PR also adds needed changes to make this work:
- Add new map point blocked possibilities:
  - North-East
  - North-West
  - South-East
  - South-West
- Update the key checking
- Update the [map editor](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs-Map-Editor) script
- Update the `vanilla-environment` submodule to add the new changes
- Update the vanilla map to include data changes
- Update the [Bane-Of-Wargs-Progression](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs-Progression) github repository

## Testing Done
Everything tested when coded.

## Performance Impact
Minor impact, with no perceptible changes.

## Check-List
- [x] Code move functions
- [x] Update the key checking to include new moving possibilities
- [x] Update the [map editor](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs-Map-Editor) script to include data changes
- [x] Update the `vanilla-environment` submodule to add the new changes
- [x] Update the vanilla map to include data changes
- [x] Update the [Bane-Of-Wargs-Progression](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs-Progression) github repository
- [x] Update the [map point creation](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs/wiki/Creating-Map-Points) wiki page
- [x] Update the [Gameplay Guide](https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs/wiki/Gameplay-Guide) wiki page
- [x] Update the UI to display if the player can go north-east etc...
- [x] Fix the checks
