### PR TITLE
PROGRESS: Allow Dialog To Run Custom Scripts

### DIFF
--- a/source/battle.py
+++ b/source/battle.py
@@ -206,7 +206,7 @@ def encounter_text_show(
     player, item, enemy, map, map_location, enemies_remaining, lists,
     defeat_percentage, preferences, drinks, npcs, zone, mounts, mission,
     start_player, dialog, text_replacements_generic, player_damage_coefficient,
-    previous_player, save_file
+    previous_player, save_file, start_time
 ):
     # import stats
     global turn, defend, fighting, already_encountered
@@ -298,7 +298,8 @@ def encounter_text_show(
                 item_input, item, player, preferences, drinks,
                 enemy, npcs, start_player, lists, zone, dialog, mission,
                 mounts, text_replacements_generic, item, map_location,
-                player_damage_coefficient, previous_player, save_file
+                player_damage_coefficient, previous_player, save_file,
+                start_time
             )
             text = '='
             text_handling.print_separator(text)
@@ -494,18 +495,12 @@ def fight(
                             cout("You are now holding a/an ", player["held shield"])
                         elif item[item_input]["type"] == "Utility":
                             cout(" ")
-                            if preferences["latest preset"]["type"] == 'plugin':
-                                script_handling.load_script(
-                                    item_input, preferences, player, map, item, drinks, enemy, npcs,
-                                    start_player, lists, zone, dialog, mission, mounts, start_time,
-                                    text_replacements_generic, plugin=True
-                                )
-                            else:
-                                script_handling.load_script(
-                                    item_input, preferences, player, map, item, drinks, enemy, npcs,
-                                    start_player, lists, zone, dialog, mission, mounts, start_time,
-                                    text_replacements_generic
-                                )
+                            plugin = preferences["latest preset"]["type"] == "plugin"
+                            script_handling.load_script(
+                                item[item_input], preferences, player, map, item, drinks, enemy, npcs,
+                                start_player, lists, zone, dialog, mission, mounts, start_time,
+                                text_replacements_generic, plugin
+                            )
                         text = '='
                         text_handling.print_separator(text)
                         cout(" ")

--- a/source/battle.py
+++ b/source/battle.py
@@ -480,19 +480,19 @@ def fight(
                         # hold weapon/armor piece if it is one
                         elif item[item_input]["type"] == "Weapon":
                             player["held item"] = item_input
-                            cout("You are now holding a/an ", player["held item"])
+                            cout("You are now holding " + text_handling.a_an_check(player["held item"]))
                         elif item[item_input]["type"] == "Armor Piece: Chestplate":
                             player["held chestplate"] = item_input
-                            cout("You are now wearing a/an ", player["held chestplate"])
+                            cout("You are now wearing " + text_handling.a_an_check(player["held chestplate"]))
                         elif item[item_input]["type"] == "Armor Piece: Leggings":
                             player["held leggings"] = item_input
-                            cout("You are now wearing a/an ", player["held leggings"])
+                            cout("You are now wearing " + text_handling.a_an_check(player["held leggings"]))
                         elif item[item_input]["type"] == "Armor Piece: Boots":
                             player["held boots"] = item_input
-                            cout("You are now wearing a/an ", player["held boots"])
+                            cout("You are now wearing " + text_handling.a_an_check(player["held boots"]))
                         elif item[item_input]["type"] == "Armor Piece: Shield":
                             player["held shield"] = item_input
-                            cout("You are now holding a/an ", player["held shield"])
+                            cout("You are now holding " + text_handling.a_an_check(player["held shield"]))
                         elif item[item_input]["type"] == "Utility":
                             cout(" ")
                             plugin = preferences["latest preset"]["type"] == "plugin"
@@ -530,7 +530,7 @@ def fight(
                         if enemy_critical_hit:
                             damage = damage * 2
                         player["health"] -= damage
-                        cout("The enemy dealt ", str(damage), " points of damage.")
+                        cout("The enemy dealt " + str(damage) + " points of damage.")
                     cout(" ")
                     turn = True
                 else:

--- a/source/consumable_handling.py
+++ b/source/consumable_handling.py
@@ -239,10 +239,18 @@ def attributes_addition_effect(current_effect_data, player):
             player["attributes"] += [i]
 
 
-def dialog_displaying_effect(current_effect_data, player, dialog, preferences, text_replacements_generic, drinks):
+def dialog_displaying_effect(
+    current_effect_data, player, dialog, preferences, text_replacements_generic, drinks,
+    item, enemy, npcs, start_player, lists, zone, mission, mounts, start_time, map
+):
     cout("")
     text_handling.print_separator("=")
-    dialog_handling.print_dialog(current_effect_data["dialog"], dialog, preferences, text_replacements_generic, player, drinks)
+    dialog_handling.print_dialog(
+        current_effect_data["dialog"], dialog, preferences,
+        text_replacements_generic, player, drinks,
+        item, enemy, npcs, start_player, lists, zone,
+        mission, mounts, start_time, map
+    )
     text_handling.print_separator("=")
     cout("")
 
@@ -288,7 +296,8 @@ def consume_consumable(
     dialog, preferences, text_replacements_generic,
     lists, map_location, enemy, item, drinks,
     start_player, npcs, zone,
-    mounts, mission, player_damage_coefficient, previous_player
+    mounts, mission, player_damage_coefficient, previous_player,
+    save_file, map, start_time
 ):
     # First, load the consumable data and stores
     # it in a variable, then remove the item
@@ -338,7 +347,10 @@ def consume_consumable(
                 elif current_effect_type == "attributes addition":
                     attributes_addition_effect(current_effect_data, player)
                 elif current_effect_type == "dialog displaying":
-                    dialog_displaying_effect(current_effect_data, player, dialog, preferences, text_replacements_generic, drinks)
+                    dialog_displaying_effect(
+                        current_effect_data, player, dialog, preferences, text_replacements_generic, drinks,
+                        item, enemy, npcs, start_player, lists, zone, mission, mounts, start_time, map
+                    )
                 elif current_effect_type == "enemy spawning":
                     enemy_spawning_effect(
                         current_effect_data, player, lists, map_location, enemy, item,

--- a/source/data_handling.py
+++ b/source/data_handling.py
@@ -341,9 +341,9 @@ def fsspec_download(github_file, destination_point, download_branch, download_re
         cout(
             COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" + COLOR_RESET_ALL +
             " an error occurred when trying to download game data to '" +
-            destination + "'."
+            destination + "'"
         )
-        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'.")
+        logger_sys.log_message(f"WARNING: An error occurred when downloading game data to '{destination}'")
         logger_sys.log_message("DEBUG: " + str(error))
         cout(COLOR_YELLOW + str(error) + COLOR_RESET_ALL)
         time.sleep(.5)
@@ -355,12 +355,26 @@ def temporary_git_file_download(selected_file, url):
     # clone the repository and select the chosen
     # file and export its data in a string
 
-    temporary_dir = tempfile.mkdtemp()
-    logger_sys.log_message(f"INFO: Creating temporary directory at '{temporary_dir}'")
-    git.Repo.clone_from(url, temporary_dir, depth=1)
+    try:
+        temporary_dir = tempfile.mkdtemp()
+        logger_sys.log_message(f"INFO: Creating temporary directory at '{temporary_dir}'")
+        git.Repo.clone_from(url, temporary_dir, depth=1)
 
-    with open(temporary_dir + '/' + selected_file, 'r') as f:
-        file_text_data = f.read()
+        with open(temporary_dir + '/' + selected_file, 'r') as f:
+            file_text_data = f.read()
+    except Exception as error:
+        cout(
+            COLOR_YELLOW + COLOR_STYLE_BRIGHT + "WARNING:" + COLOR_RESET_ALL +
+            f" an error occurred when trying to download file '{selected_file}' from git" +
+            f" url '{url}'"
+        )
+        logger_sys.log_message(
+            f"WARNING: An error occurred when downloading file '{selected_file}' from git url" +
+            f" '{url}'"
+        )
+        logger_sys.log_message("DEBUG: " + str(error))
+        time.sleep(3)
+        file_text_data = None
 
     return file_text_data
 

--- a/source/dialog_handling.py
+++ b/source/dialog_handling.py
@@ -3,6 +3,7 @@ from colors import *
 import logger_sys
 import text_handling
 import terminal_handling
+import script_handling
 from terminal_handling import cout, cinput
 # external imports
 import appdirs
@@ -15,7 +16,11 @@ program_dir = str(appdirs.user_config_dir(appname='Bane-Of-Wargs'))
 # Functions to handle dialogs
 
 
-def print_dialog(current_dialog, dialog, preferences, text_replacements_generic, player, drinks):
+def print_dialog(
+    current_dialog, dialog, preferences, text_replacements_generic, player, drinks,
+    item, enemy, npcs, start_player, lists, zone,
+    mission, mounts, start_time, map
+):
     current_dialog_name = current_dialog
     logger_sys.log_message(f"INFO: Printing dialog '{current_dialog_name}'")
     current_dialog = dialog[str(current_dialog)]
@@ -255,6 +260,17 @@ def print_dialog(current_dialog, dialog, preferences, text_replacements_generic,
                 else:
                     player["health"] += drinks[selected_drink]["healing level"]
 
+                count += 1
+        if "run scripts" in actions:
+            plugin = preferences["latest preset"]["type"] == "plugin"
+            count = 0
+            for script in actions["run scripts"]:
+                current_scrip_data = actions["run scripts"][count]
+                script_handling.load_script(
+                    current_scrip_data, preferences,  player, map, item, drinks, enemy, npcs,
+                    start_player, lists, zone, dialog, mission, mounts, start_time,
+                    text_replacements_generic, plugin
+                )
                 count += 1
 
 

--- a/source/dialog_handling.py
+++ b/source/dialog_handling.py
@@ -265,9 +265,9 @@ def print_dialog(
             plugin = preferences["latest preset"]["type"] == "plugin"
             count = 0
             for script in actions["run scripts"]:
-                current_scrip_data = actions["run scripts"][count]
+                current_script_data = actions["run scripts"][count]
                 script_handling.load_script(
-                    current_scrip_data, preferences,  player, map, item, drinks, enemy, npcs,
+                    current_script_data, preferences,  player, map, item, drinks, enemy, npcs,
                     start_player, lists, zone, dialog, mission, mounts, start_time,
                     text_replacements_generic, plugin
                 )

--- a/source/enemy_handling.py
+++ b/source/enemy_handling.py
@@ -52,7 +52,7 @@ def spawn_enemy(
                 player, item, enemy, map, map_location, enemies_remaining, lists,
                 defeat_percentage, preferences, drinks, npcs, zone, mounts, mission,
                 start_player, dialog, text_replacements_generic, player_damage_coefficient,
-                previous_player, save_file
+                previous_player, save_file, start_time
             )
             already_encountered = True
         logger_sys.log_message("INFO: Starting the fight")

--- a/source/item_handling.py
+++ b/source/item_handling.py
@@ -13,7 +13,7 @@ def use_item(
     which_item, item_data, player, preferences, drinks,
     enemy, npcs, start_player, lists, zone, dialog, mission,
     mounts, text_replacements_generic, item, map_location,
-    player_damage_coefficient, previous_player, save_file
+    player_damage_coefficient, previous_player, save_file, start_time
 ):
     # Load the global items data and load the
     # chosen item data and stores it to a variable
@@ -27,7 +27,7 @@ def use_item(
             lists, map_location, enemy, item, drinks,
             start_player, npcs, zone,
             mounts, mission, player_damage_coefficient, previous_player,
-            save_file
+            save_file, map, start_time
         )
         logger_sys.log_message(f"INFO: Item '{which_item}' is an item of type '{which_item_type}' --> consuming it")
     elif (
@@ -38,16 +38,13 @@ def use_item(
     elif which_item_type == "Utility":
         logger_sys.log_message(f"INFO: Item '{which_item}' is an item of type '{which_item_type}' --> loading its script")
         cout(" ")
+        plugin = False
         if preferences["latest preset"]["type"] == 'plugin':
-            script_handling.load_script(
-                which_item, preferences, player, map, item_data, drinks, enemy, npcs,
-                start_player, lists, zone, dialog, mission, mounts, plugin=True
-            )
-        else:
-            script_handling.load_script(
-                which_item, preferences, player, map, item_data, drinks, enemy, npcs,
-                start_player, lists, zone, dialog, mission, mounts
-            )
+            plugin = True
+        script_handling.load_script(
+            item[which_item], preferences, player, map, item_data, drinks, enemy, npcs,
+            start_player, lists, zone, dialog, mission, mounts, plugin
+        )
 
 
 def equip_item(item_name, player, equipment_type):

--- a/source/main.py
+++ b/source/main.py
@@ -160,74 +160,78 @@ latest_main_class = io.StringIO(data_handling.temporary_git_file_download(
     'source/main.py', 'https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs.git'
 )).readlines()
 
-continuing = True
-count = 0
-while count < len(latest_main_class) and continuing:
-    if latest_main_class[count].startswith('SOURCE_CODE_VERSION = '):
-        latest_version = latest_main_class[count].split("= ", 1)[1]
-        continuing = False
-    count += 1
+if latest_main_class == []:  # if the file didn't download
+    cout("Skipping game updating process...")
+    time.sleep(1)
+else:
+    continuing = True
+    count = 0
+    while count < len(latest_main_class) and continuing:
+        if latest_main_class[count].startswith('SOURCE_CODE_VERSION = '):
+            latest_version = latest_main_class[count].split("= ", 1)[1]
+            continuing = False
+        count += 1
 
-if float(latest_version) > float(SOURCE_CODE_VERSION):
-    latest_version = float(str(latest_version).replace('\n', ''))
-    logger_sys.log_message("WARNING: The game source code is outdated")
-    logger_sys.log_message(
-        f"DEBUG: You're using version {SOURCE_CODE_VERSION} while the latest version is {latest_version}"
-    )
-    cout(
-        COLOR_YELLOW + "WARNING: The game source code is outdated:\nYou're using " +
-        f"version {SOURCE_CODE_VERSION} while the latest version is {latest_version}" +
-        COLOR_RESET_ALL
-    )
-    time.sleep(3)
-    text_handling.clear_prompt()
-
-# Get latest game data version for later
-logger_sys.log_message(f"INFO: Checking if game data at '{program_dir}/game/' is up to date")
-global latest_game_data_version
-latest_game_data_version = None
-try:
-    with open(f'{program_dir}/game/VERSION.bow') as f:
-        GAME_DATA_VERSION = f.read().replace('\n', '')
-except Exception as error:
-    cout(f"ERROR: Couldn't find required file '{program_dir}/game/VERSION.bow'")
-    cout(f"DEBUG: Please try to restart the game with the preferences option 'auto update' turned on")
-    logger_sys.log_message(f"ERROR: Couldn't find required file '{program_dir}/game/VERSION.bow'")
-    logger_sys.log_message(f"DEBUG: Please try to restart the game with the preferences option 'auto update' turned on")
-    time.sleep(3)
-    text_handling.exit_game()
-
-continuing = True
-count = 0
-while count < len(latest_main_class) and continuing:
-    if latest_main_class[count].startswith('    GAME_DATA_VERSION = '):
-        latest_game_data_version = latest_main_class[count].split("= ", 1)[1]
-        continuing = False
-    count += 1
-
-if preferences["auto update"] or first_start:
-    data_handling.update_game_data(preferences, latest_game_data_version)
-
-# Compare the latest game data version with
-# the current game data version
-if float(GAME_DATA_VERSION) < float(latest_game_data_version):
-    latest_game_data_version = float(str(latest_game_data_version).replace('\n', ''))
-    logger_sys.log_message(f"WARNING: The game data at '{program_dir}' is outdated")
-    logger_sys.log_message(
-        f"DEBUG: You're using version {GAME_DATA_VERSION} while the latest version is {latest_game_data_version}"
-    )
-    cout(
-        COLOR_YELLOW + f"WARNING: The game data at '{program_dir}' is outdated:\nYou're using " +
-        f"version {GAME_DATA_VERSION} while the latest version is {latest_game_data_version}" +
-        COLOR_RESET_ALL
-    )
-    time.sleep(3)
-    cout("\nDo you want to update your game data right now?")
-    want_to_update = terminal_handling.show_menu(["Yes", "No"])
-    if want_to_update == "Yes":
+    if float(latest_version) > float(SOURCE_CODE_VERSION):
+        latest_version = float(str(latest_version).replace('\n', ''))
+        logger_sys.log_message("WARNING: The game source code is outdated")
+        logger_sys.log_message(
+            f"DEBUG: You're using version {SOURCE_CODE_VERSION} while the latest version is {latest_version}"
+        )
+        cout(
+            COLOR_YELLOW + "WARNING: The game source code is outdated:\nYou're using " +
+            f"version {SOURCE_CODE_VERSION} while the latest version is {latest_version}" +
+            COLOR_RESET_ALL
+        )
+        time.sleep(3)
         text_handling.clear_prompt()
+
+    # Get latest game data version
+    logger_sys.log_message(f"INFO: Checking if game data at '{program_dir}/game/' is up to date")
+    global latest_game_data_version
+    latest_game_data_version = None
+    try:
+        with open(f'{program_dir}/game/VERSION.bow') as f:
+            GAME_DATA_VERSION = f.read().replace('\n', '')
+    except Exception as error:
+        cout(f"ERROR: Couldn't find required file '{program_dir}/game/VERSION.bow'")
+        cout(f"DEBUG: Please try to restart the game with the preferences option 'auto update' turned on")
+        logger_sys.log_message(f"ERROR: Couldn't find required file '{program_dir}/game/VERSION.bow'")
+        logger_sys.log_message(f"DEBUG: Please try to restart the game with the preferences option 'auto update' turned on")
+        time.sleep(3)
+        text_handling.exit_game()
+
+    continuing = True
+    count = 0
+    while count < len(latest_main_class) and continuing:
+        if latest_main_class[count].startswith('    GAME_DATA_VERSION = '):
+            latest_game_data_version = latest_main_class[count].split("= ", 1)[1]
+            continuing = False
+        count += 1
+
+    if preferences["auto update"] or first_start:
         data_handling.update_game_data(preferences, latest_game_data_version)
-    text_handling.clear_prompt()
+
+    # Compare the latest game data version with
+    # the current game data version
+    if float(GAME_DATA_VERSION) < float(latest_game_data_version):
+        latest_game_data_version = float(str(latest_game_data_version).replace('\n', ''))
+        logger_sys.log_message(f"WARNING: The game data at '{program_dir}' is outdated")
+        logger_sys.log_message(
+            f"DEBUG: You're using version {GAME_DATA_VERSION} while the latest version is {latest_game_data_version}"
+        )
+        cout(
+            COLOR_YELLOW + f"WARNING: The game data at '{program_dir}' is outdated:\nYou're using " +
+            f"version {GAME_DATA_VERSION} while the latest version is {latest_game_data_version}" +
+            COLOR_RESET_ALL
+        )
+        time.sleep(3)
+        cout("\nDo you want to update your game data right now?")
+        want_to_update = terminal_handling.show_menu(["Yes", "No"])
+        if want_to_update == "Yes":
+            text_handling.clear_prompt()
+            data_handling.update_game_data(preferences, latest_game_data_version)
+        text_handling.clear_prompt()
 
 # main menu start
 while menu:
@@ -1469,7 +1473,7 @@ def run(play):
                 mission_handling.mission_completing_checks(
                     str(player["active missions"][count]), mission, player, dialog, preferences,
                     text_replacements_generic, drinks, item, enemy, npcs, start_player,
-                    lists, zone, mission, mounts, start_time, current_scrip_data
+                    lists, zone, mission, mounts, start_time
                 )
 
             count += 1

--- a/source/main.py
+++ b/source/main.py
@@ -1245,8 +1245,9 @@ def run(play):
             start_dialog = player["start dialog"]["dialog"]
             logger_sys.log_message(f"INFO: Displaying start dialog '{start_dialog}' to player")
             dialog_handling.print_dialog(
-                start_dialog, dialog, preferences,
-                text_replacements_generic, player, drinks
+                start_dialog, dialog, preferences, text_replacements_generic, player, drinks,
+                item, enemy, npcs, start_player, lists, zone,
+                mission, mounts, start_time, map
             )
             text = '='
             text_handling.print_separator(text)
@@ -1342,7 +1343,11 @@ def run(play):
                     f"INFO: Player has all required stuff to display dialog '{current_dialog}'" +
                     f" --> displaying it and adding map location '{map_location}' to the player's heard dialogs save list"
                 )
-                dialog_handling.print_dialog(current_dialog, dialog, preferences, text_replacements_generic, player, drinks)
+                dialog_handling.print_dialog(
+                    current_dialog, dialog, preferences, text_replacements_generic, player, drinks,
+                    item, enemy, npcs, start_player, lists, zone,
+                    mission, mounts, start_time, map
+                )
                 player["heard dialogs"].append(map_location)
                 text = '='
                 text_handling.print_separator(text)
@@ -1402,8 +1407,9 @@ def run(play):
             ) not in player["offered missions"]:
                 logger_sys.log_message(f"INFO: Offering mission '{str(list(mission)[count])}' to player")
                 mission_handling.offer_mission(
-                    str(list(mission)[count]), player, mission, dialog,
-                    preferences, text_replacements_generic, drinks
+                    str(list(mission)[count]), player, mission, dialog, preferences,
+                    text_replacements_generic, drinks, item, enemy, npcs,
+                    start_player, lists, zone, mission, mounts, start_time, map
                 )
 
             count += 1
@@ -1461,8 +1467,9 @@ def run(play):
             if current_mission_data["destination"] == map_location:
                 logger_sys.log_message(f"INFO: Running mission completing checks for mission data '{current_mission_data}'")
                 mission_handling.mission_completing_checks(
-                    str(player["active missions"][count]), mission, player,
-                    dialog, preferences, text_replacements_generic, drinks
+                    str(player["active missions"][count]), mission, player, dialog, preferences,
+                    text_replacements_generic, drinks, item, enemy, npcs, start_player,
+                    lists, zone, mission, mounts, start_time, current_scrip_data
                 )
 
             count += 1
@@ -1484,7 +1491,8 @@ def run(play):
                     logger_sys.log_message(f"INFO: Executing failing triggers of mission data '{current_mission_data}'")
                     mission_handling.execute_triggers(
                         current_mission_data, player, 'on fail', dialog, preferences,
-                        text_replacements_generic, drinks
+                        text_replacements_generic, drinks, item, enemy, npcs,
+                        start_player, lists, zone, mission, mounts, start_time, map
                     )
                     cout(
                         COLOR_RED + COLOR_STYLE_BRIGHT + "You failed mission '" +
@@ -1532,8 +1540,9 @@ def run(play):
                             )
                             if "dialog" in current_enemy_data:
                                 dialog_handling.print_dialog(
-                                    current_enemy_data["dialog"], dialog, preferences,
-                                    text_replacements_generic, player, drinks
+                                    current_enemy_data["dialog"], dialog, preferences, text_replacements_generic, player, drinks,
+                                    item, enemy, npcs, start_player, lists, zone,
+                                    mission, mounts, start_time, map
                                 )
 
                     count2 += 1
@@ -2421,8 +2430,8 @@ def run(play):
                         dialog, preferences, text_replacements_generic,
                         lists, map_location, enemy, item, drinks,
                         start_player, npcs, zone,
-                        mounts, mission, player_damage_coefficient,
-                        previous_player, save_file
+                        mounts, mission, player_damage_coefficient, previous_player,
+                        save_file, map, start_time
                     )
                 elif choice == 'Get Rid':
                     text = (
@@ -2759,18 +2768,12 @@ def run(play):
                 continued_command = True
                 current_utility = i
                 if command == item[current_utility]["key"] and current_utility in player["inventory"]:
-                    if preferences["latest preset"]["type"] == "plugin":
-                        script_handling.load_script(
-                            current_utility, preferences, player, map, item, drinks, enemy, npcs,
-                            start_player, lists, zone, dialog, mission, mounts, start_time,
-                            text_replacements_generic, plugin=True
-                        )
-                    else:
-                        script_handling.load_script(
-                            current_utility, preferences, player, map, item, drinks, enemy, npcs,
-                            start_player, lists, zone, dialog, mission, mounts, start_time,
-                            text_replacements_generic
-                        )
+                    plugin = preferences["latest preset"]["type"] == "plugin"
+                    script_handling.load_script(
+                        current_utility, preferences, player, map, item, drinks, enemy, npcs,
+                        start_player, lists, zone, dialog, mission, mounts, start_time,
+                        text_replacements_generic, plugin
+                    )
                     continued_utility = True
                     cinput()
                 elif current_utility not in player["inventory"] and command == item[current_utility]["key"]:

--- a/source/mission_handling.py
+++ b/source/mission_handling.py
@@ -203,7 +203,12 @@ def mission_checks(mission_data, player, which_key):
     return checks_passed
 
 
-def execute_triggers(mission_data, player, which_key, dialog, preferences, text_replacements_generic, drinks):
+def execute_triggers(
+    mission_data, player, which_key, dialog, preferences,
+    text_replacements_generic, drinks, item, enemy, npcs,
+    start_player, lists, zone, mission, mounts, start_time,
+    map
+):
     # If which_key input is invalid, quit
     # the game and output the error to the
     # game logs files
@@ -218,8 +223,9 @@ def execute_triggers(mission_data, player, which_key, dialog, preferences, text_
     if which_key in mission_data:
         if "dialog" in mission_data[which_key]:
             dialog_handling.print_dialog(
-                mission_data[which_key]["dialog"], dialog, preferences,
-                text_replacements_generic, player, drinks
+                mission_data[which_key]["dialog"], dialog, preferences, text_replacements_generic, player, drinks,
+                item, enemy, npcs, start_player, lists, zone,
+                mission, mounts, start_time, map
             )
         if "payment" in mission_data[which_key]:
             player["gold"] += mission_data[which_key]["payment"]
@@ -229,7 +235,12 @@ def execute_triggers(mission_data, player, which_key, dialog, preferences, text_
             player["xp"] += mission_data[which_key]["exp addition"]
 
 
-def offer_mission(mission_id, player, missions_data, dialog, preferences, text_replacements_generic, drinks):
+def offer_mission(
+    mission_id, player, missions_data, dialog, preferences,
+    text_replacements_generic, drinks, item, enemy, npcs,
+    start_player, lists, zone, mission, mounts, start_time,
+    map
+):
     logger_sys.log_message(f"INFO: Offering mission '{mission_id}' to player")
     data = missions_data[mission_id]
 
@@ -262,7 +273,9 @@ def offer_mission(mission_id, player, missions_data, dialog, preferences, text_r
             # else, make the player automatically accept it
             if "dialog" in list(data["on offer"]):
                 dialog_handling.print_dialog(
-                    data["on offer"]["dialog"], dialog, preferences, text_replacements_generic, player, drinks
+                    data["on offer"]["dialog"], dialog, preferences, text_replacements_generic, player, drinks,
+                    item, enemy, npcs, start_player, lists, zone,
+                    mission, mounts, start_time, map
                 )
                 if "force accept" in list(data):
                     if not data["force accept"]:
@@ -297,7 +310,11 @@ def offer_mission(mission_id, player, missions_data, dialog, preferences, text_r
         logger_sys.log_message(f"INFO: Finished triggering mission '{mission_id}' 'on offer' triggers")
 
 
-def mission_completing_checks(mission_id, missions_data, player, dialog, preferences, text_replacements_generic, drinks):
+def mission_completing_checks(
+    mission_id, missions_data, player, dialog, preferences,
+    text_replacements_generic, drinks, item, enemy, npcs, start_player,
+    lists, zone, mission, mounts, start_time, current_scrip_data
+):
     # Load mission data and check if the
     # required attributes to complete the
     # mission are here and also check if the
@@ -325,7 +342,12 @@ def mission_completing_checks(mission_id, missions_data, player, dialog, prefere
     if attributes_checks_passed and stopovers_checks_passed:
         logger_sys.log_message(f"INFO: Executing mission '{mission_id}' completing triggers")
 
-        execute_triggers(mission_data, player, 'on complete', dialog, preferences, text_replacements_generic, drinks)
+        execute_triggers(
+            mission_data, player, 'on complete', dialog, preferences,
+            text_replacements_generic, drinks, item, enemy, npcs,
+            start_player, lists, zone, mission, mounts, start_time,
+            map
+        )
 
         logger_sys.log_message(f"INFO: Set mission '{mission_id}' as done")
         cout(COLOR_CYAN + COLOR_STYLE_BRIGHT + "You completed mission '" + mission_data["name"] + "'" + COLOR_RESET_ALL)

--- a/source/mission_handling.py
+++ b/source/mission_handling.py
@@ -227,6 +227,7 @@ def execute_triggers(
                 item, enemy, npcs, start_player, lists, zone,
                 mission, mounts, start_time, map
             )
+            text_handling.print_separator('=')
         if "payment" in mission_data[which_key]:
             player["gold"] += mission_data[which_key]["payment"]
         if "fine" in mission_data[which_key]:
@@ -284,7 +285,7 @@ def offer_mission(
                         accept = "y"
                 else:
                     accept = cinput("Do you want to accept this task? (y/n)")
-                cout("=======================================================")
+                text_handling.print_separator('=')
                 if accept.startswith('y'):
                     if player["active missions"] is None:
                         player["active missions"] = []
@@ -313,7 +314,7 @@ def offer_mission(
 def mission_completing_checks(
     mission_id, missions_data, player, dialog, preferences,
     text_replacements_generic, drinks, item, enemy, npcs, start_player,
-    lists, zone, mission, mounts, start_time, current_scrip_data
+    lists, zone, mission, mounts, start_time
 ):
     # Load mission data and check if the
     # required attributes to complete the

--- a/source/script_handling.py
+++ b/source/script_handling.py
@@ -15,46 +15,45 @@ program_dir = str(appdirs.user_config_dir(appname='Bane-Of-Wargs'))
 # Handling Functions
 
 def load_script(
-    current_utility, preferences, player, map, item, drinks, enemy, npcs,
+    script_data, preferences, player, map, item, drinks, enemy, npcs,
     start_player, lists, zone, dialog, mission, mounts, start_time,
     generic_text_replacements, plugin=False
 ):
-    logger_sys.log_message(f"INFO: Player is using utility item '{current_utility}'")
     if plugin:
         with open(
             program_dir + '/plugins/' + preferences["latest preset"]["plugin"] +
-            '/scripts/' + item[current_utility]["script name"]
+            '/scripts/' + script_data["script name"]
         ) as f:
             execute_script(
-                f, current_utility, player, map, item, drinks, enemy, npcs,
+                script_data, f, player, map, item, drinks, enemy, npcs,
                 start_player, lists, zone, dialog, mission, mounts, start_time,
                 generic_text_replacements
             )
     else:
         with open(
-            program_dir + '/game/scripts/' + item[current_utility]["script name"]
+            program_dir + '/game/scripts/' + script_data["script name"]
         ) as f:
             execute_script(
-                f, current_utility, player, map, item, drinks, enemy, npcs,
+                script_data, f, player, map, item, drinks, enemy, npcs,
                 start_player, lists, zone, dialog, mission, mounts, start_time,
                 generic_text_replacements
             )
 
 
 def execute_script(
-    file, current_utility, player, map, item, drinks, enemy, npcs,
+    script_data, file, player, map, item, drinks, enemy, npcs,
     start_player, lists, zone, dialog, mission, mounts, start_time,
     generic_text_replacements
 ):
     logger_sys.log_message(
-        f"INFO: Starting execution process of script '{file}' from utility '{current_utility}'"
+        f"INFO: Starting execution process of script '{file}'"
     )
     global_arguments = {}
     logger_sys.log_message(
-        f"INFO: Loading script '{file}' from utility '{current_utility}' required arguments"
+        f"INFO: Loading script '{file}' required arguments"
     )
-    if "arguments" in item[current_utility]:
-        arguments = item[current_utility]['arguments']
+    if "arguments" in script_data:
+        arguments = script_data['arguments']
         if "player" in arguments:
             global_arguments["player"] = player
         if "map" in arguments:
@@ -84,18 +83,18 @@ def execute_script(
         if "generic_text_replacements" in arguments:
             global_arguments["generic_text_replacements"] = generic_text_replacements
     logger_sys.log_message(
-        f"INFO: Loaded script '{file}' from utility '{current_utility}' required arguments:\n{global_arguments}"
+        f"INFO: Loaded script '{file}' required arguments:\n{global_arguments}"
     )
     logger_sys.log_message(
-        f"INFO: Executing script '{file}' from utility '{current_utility}' with arguments '{global_arguments}'"
+        f"INFO: Executing script '{file}' with arguments '{global_arguments}'"
     )
     try:
         exec(file.read(), global_arguments)
     except Exception as error:
         cout(COLOR_RED + "ERROR: " + COLOR_STYLE_BRIGHT + str(error) + COLOR_RESET_ALL)
         logger_sys.log_message(
-            f"ERROR: An error occurred when executing script '{file}' from utility " +
-            f"'{current_utility}' with arguments '{global_arguments}'"
+            f"ERROR: An error occurred when executing script '{file}' " +
+            f"'with arguments '{global_arguments}'"
         )
         logger_sys.log_message(f"DEBUG: error message --> '{error}'")
         time.sleep(5)

--- a/source/time_handling.py
+++ b/source/time_handling.py
@@ -68,7 +68,7 @@ def date_prettifier(date):
 
 def get_day_time(game_days):
     # calculate day time
-    day_time = "PLACEHOLDER"  # .25 = morning .50 = day .75 = evening .0 = night
+    day_time = COLOR_BLUE + COLOR_STYLE_BRIGHT + "▲ MORNING" + COLOR_RESET_ALL  # .25 = morning .50 = day .75 = evening .0 = night
     day_time_decimal = "." + str(game_days).split(".", 1)[1]
     day_time_decimal = float(day_time_decimal)
     if day_time_decimal < .25 and day_time_decimal > .0:


### PR DESCRIPTION
# PROGRESS

This PR addresses the game progression goal #'Allow dialogs actions to run custom scripts'

## Summary
This PR adds a new action to dialogs:

```yaml
dialog test:
  [...] # dialog data
  actions:
    run scripts:
      - script 1:
        arguments:
        - player
        - map
        - zone
        - start_time
        script name: map_item.py
      - script 2:
        script name: rock_paper_scissors_game.py
```

---

This PR also make so that there isn't any error anymore when running the game without an internet connection.

## Usage examples
There're only a few of the game data that you can change during the game. In order to add more possibilities to the plot, adding custom scripts that can be ran in dialogs lets the game data really modify everything.

## Testing Done
I'll go over the whole current vanilla plot to test if there isn't any bugs.

## Performance Impact
N/A

## Check-List
- [x] Code the code
- [x] Test the code
- [x] Update the wiki
- [x] Fix the checks
