### PR TITLE
FEATURE: Traveling Rework & Mounts Stats Addition

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,4 +109,4 @@ Here are the main code style conventions:
   - You shouldn't worry about that checks too much
 
 ## Merging Pull Requests
-When you merge a pull request, please `Squash Merge`, remove commit listing, use the [naming convention](#naming-conventions), and add extra details if necessary. You do not have to use the name of a PR in the commit name. Note that before merging, every github action checks must be passing.
+When you merge a pull request, please `Squash Merge`, remove commit listing, use the [naming convention](#naming-conventions), and add extra details if necessary. You do not have to use the name of a PR in the commit name. Note that before merging, every github action checks must be passing. If the PR you're merging updates the `GAME_SOURCE_CODE_VERSION` and `GAME_DATA_VERSION` constants in the `main.py` class, please specify it in the commit description.

--- a/data/mounts.yaml
+++ b/data/mounts.yaml
@@ -2,6 +2,7 @@ Warg:
   name: Warg
   plural: Wargs
   gold: 59.36
+  mph: 24
   feed:
     food:
     - Beef
@@ -19,11 +20,13 @@ Warg:
     level stat additions:
       agility addition: .025
       resistance addition: .015
+      mph addition: .25
   description: "Wargs are at first Yrch mounts but they can be tamed and then used to fight against Yrch. Wargs are fast and agile mounts."
 White Warg:
   name: White Warg
   plural: White Wargs
   gold: 320.34
+  mph: 29
   feed:
     food:
     - Beef
@@ -41,11 +44,13 @@ White Warg:
     level stat additions:
       agility addition: .015
       resistance addition: .01
+      mph addition: .2
   description: "Wargs are at first Yrch mounts but they can be tamed and then used to fight against Yrch. Wargs are fast and agile mounts."
 Bear:
   name: Bear
   plural: Bears
   gold: 79.58
+  mph: 15
   feed:
     food:
     - Beef
@@ -62,11 +67,13 @@ Bear:
     level stat additions:
       agility addition: .015
       resistance addition: .15
+      mph addition: .2
   description: "Bears are very big and powerful animals that are very hard to train; they required lot of work."
 Horse:
   name: Horse
   plural: Horses
   gold: 54.23
+  mph: 17
   feed:
     food:
     - Carrot
@@ -84,11 +91,13 @@ Horse:
     level stat additions:
       agility addition: .015
       resistance addition: .005
+      mph addition: .25
   description: "There are many different species of horses that you can find in the Kathallion Plains. This is a generic horse that you can find almost anywhere in the Kathallion Plains."
 Friesian Horse:
   name: Friesian Horse
   plural: Friesian Horses
   gold: 74.35
+  mph: 18
   feed:
     food:
     - Hay Bale
@@ -105,11 +114,13 @@ Friesian Horse:
     level stat additions:
       agility addition: .016
       resistance addition: .007
+      mph addition: .26
   description: "Friesian Horses are breeds who are known for their docile ,energetic and swift high-stepping trot. They are often used by knights."
 Shire Horse:
   name: Shire Horse
   plural: Shire Horses
   gold: 63.35
+  mph: 16
   feed:
     food:
     - Hay Bale
@@ -126,11 +137,13 @@ Shire Horse:
     level stat additions:
       agility addition: .015
       resistance addition: .02
+      mph addition: .15
   description: "Shire Horses are tall horses that are often used by farmers to labor their lands. Despite that, they are also great horses for knights. "
 Camel:
   name: Camel
   plural: Camels
   gold: 76.42
+  mph: 10
   feed:
     food:
     - Wheat
@@ -149,6 +162,7 @@ Camel:
     level stat additions:
       agility addition: .011
       resistance addition: .023
+      mph addition: .1
   description: >
     Camels are mounts used by the merchants of the Gerud Valleys, who often need to cross the whole Gerud Desert
     and sometimes the Badlands to get to their destination.
@@ -156,6 +170,7 @@ Donkey:
   name: Donkey
   plural: Donkeys
   gold: 84.58
+  mph: 11
   feed:
     food:
     - Carrot
@@ -172,6 +187,7 @@ Donkey:
     level stat additions:
       agility addition: .01
       resistance addition: .021
+      mph addition: .13
   description: >
     Donkeys are not from the Stall Island, but some explorer brought them a few centuries ago and they're now often used by
     merchants that want to cross the difficult Goro Mounts or the wild Mangrove Wastes.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -109,4 +109,4 @@ Here are the main code style conventions:
   - You shouldn't worry about that checks too much
 
 ## Merging Pull Requests
-When you merge a pull request, please `Squash Merge`, remove commit listing, use the [naming convention](#naming-conventions), and add extra details if necessary. You do not have to use the name of a PR in the commit name. Note that before merging, every github action checks must be passing.
+When you merge a pull request, please `Squash Merge`, remove commit listing, use the [naming convention](#naming-conventions), and add extra details if necessary. You do not have to use the name of a PR in the commit name. Note that before merging, every github action checks must be passing. If the PR you're merging updates the `GAME_SOURCE_CODE_VERSION` and `GAME_DATA_VERSION` constants in the `main.py` class, please specify it in the commit description.

--- a/schemas/mounts.yaml
+++ b/schemas/mounts.yaml
@@ -1,6 +1,7 @@
 name: str()
 plural: str()
 gold: num()
+mph: int()
 feed:
   food: list(str())
   feed needs: num()
@@ -15,4 +16,5 @@ levels:
   level stat additions:
     agility addition: num()
     resistance addition: num()
+    mph addition: num()
 description: str()

--- a/source/main.py
+++ b/source/main.py
@@ -103,7 +103,7 @@ menu = True
 program_dir = str(appdirs.user_config_dir(appname='Bane-Of-Wargs'))
 first_start = False
 if not os.path.exists(program_dir):
-    GAME_DATA_VERSION = 0.15
+    GAME_DATA_VERSION = 0.16
     os.mkdir(program_dir)
     # Open default config file and store the text into
     # a variable to write it into the user config file
@@ -155,7 +155,7 @@ with open(program_dir + '/preferences.yaml', 'r') as f:
 logger_sys.log_message("INFO: Checking if game source code is up to date")
 global latest_version
 latest_version = None  # placeholder
-SOURCE_CODE_VERSION = 0.15
+SOURCE_CODE_VERSION = 0.16
 latest_main_class = io.StringIO(data_handling.temporary_git_file_download(
     'source/main.py', 'https://github.com/Dungeons-of-Kathallion/Bane-Of-Wargs.git'
 )).readlines()
@@ -2677,7 +2677,7 @@ def run(play):
                     )
                     cout(
                         "  MPH: " + COLOR_BACK_BLUE + COLOR_STYLE_BRIGHT +
-                        str(which_mount_data["mph"]) + COLOR_RESET_ALL
+                        str(round(which_mount_data["mph"], 1)) + COLOR_RESET_ALL
                     )
                     cout(" ")
 

--- a/source/time_handling.py
+++ b/source/time_handling.py
@@ -1,12 +1,16 @@
 # source imports
+import logger_sys
 from colors import *
+from terminal_handling import cout
 # external imports
 import calendar
+import time
 from datetime import datetime, timedelta
 
 
 # Constants
 COEFFICIENT = (1 / 720)
+TRAVELING_WAIT = (1 / 7.3)
 
 # Handling Functions
 
@@ -15,6 +19,7 @@ def addition_to_date(date, addition):
     # Get month, day and year and then
     # calculate the addition and return
     # the value
+    logger_sys.log_message(f"INFO: Calculating addition of {addition} days to date {date}")
     separated_date = date.split('-', 2)
     month = separated_date[0]
     day = separated_date[1]
@@ -30,6 +35,7 @@ def addition_to_date(date, addition):
     new_year = future_date[0]
 
     future_date = f"{new_month}-{new_day}-{new_year}"
+    logger_sys.log_message(f"INFO: Calculated addition of {addition} days to date {date} --> {future_date}")
 
     return future_date
 
@@ -37,6 +43,7 @@ def addition_to_date(date, addition):
 def date_prettifier(date):
     # Get month, day and year and then
     # prettify them and return the value
+    logger_sys.log_message(f"INFO: Prettifying date {date}")
     separated_date = date.split('-', 2)
     month = calendar.month_name[int(separated_date[0])]
     day = separated_date[1]
@@ -62,6 +69,7 @@ def date_prettifier(date):
     if day.startswith("0"):
         day = day.replace("0", "")
     formatted_date = f"{day} {month}, year {year}"
+    logger_sys.log_message(f"INFO: Prettified data {date} -- > {formatted_date}")
 
     return formatted_date
 
@@ -79,11 +87,31 @@ def get_day_time(game_days):
         day_time = COLOR_GREEN + COLOR_STYLE_BRIGHT + "☼ DAY" + COLOR_RESET_ALL
     elif day_time_decimal > .75 and day_time_decimal:
         day_time = COLOR_YELLOW + COLOR_STYLE_BRIGHT + "▼ EVENING" + COLOR_RESET_ALL
+    logger_sys.log_message(f"INFO: Calculated day time of game day decimal '{game_days}' --> '{day_time}'")
 
     return day_time
 
 
 def return_game_day_from_seconds(seconds, time_elapsing_coefficient):
+    logger_sys.log_message(
+        f"INFO: Calculating in-game days from seconds '{seconds}', with coefficient '{
+            time_elapsing_coefficient * COEFFICIENT
+        }'"
+    )
     game_days = seconds * COEFFICIENT * time_elapsing_coefficient  # 12 minutes irl = one whole game day (1=720*x)
 
     return game_days
+
+def traveling_wait(traveling_coefficient):
+    traveling_time = traveling_coefficient * TRAVELING_WAIT
+    logger_sys.log_message(f"INFO: Running traveling waiting time: {traveling_time * 5} seconds of wait")
+    cout("...", end="\r")
+    time.sleep(traveling_time)
+    cout("ø..", end="\r")
+    time.sleep(traveling_time)
+    cout(".ø.", end="\r")
+    time.sleep(traveling_time)
+    cout("..ø", end="\r")
+    time.sleep(traveling_time)
+    cout("...")
+    time.sleep(traveling_time)

--- a/source/time_handling.py
+++ b/source/time_handling.py
@@ -102,6 +102,7 @@ def return_game_day_from_seconds(seconds, time_elapsing_coefficient):
 
     return game_days
 
+
 def traveling_wait(traveling_coefficient):
     traveling_time = traveling_coefficient * TRAVELING_WAIT
     logger_sys.log_message(f"INFO: Running traveling waiting time: {traveling_time * 5} seconds of wait")

--- a/source/zone_handling.py
+++ b/source/zone_handling.py
@@ -513,7 +513,8 @@ def interaction_stable(map_zone, zone, player, item, drinks, mounts, map_locatio
                             "location": "point" + str(map_location),
                             "mount": str(which_mount),
                             "name": str(new_mount_name),
-                            "stats": mount_stats
+                            "stats": mount_stats,
+                            "mph": mounts[which_mount]["mph"]
                         }
                         logger_sys.log_message(f"INFO: Created new mount stats: '{mount_dict}'")
                         player["mounts"][generated_mount_uuid] = mount_dict


### PR DESCRIPTION
# FEATURE/CONTENT

## Summary
This PR adds a new mechanic: the time travel wait. Now, when traveling you'll have a tiny loading screen that lasts approximately a second by default. There's a constant time traveling coefficient, stored in the `time_handling.py` class, and a time traveling coefficient variable, stored in the `main.py` class. This variable is increased, depending on your 'inventory weight', which is equal to: `len(player["inventory"]) / 100`.

---

Mounts now have a new `mph` attribute, which is used to reduce the time traveling coefficient variable. The reduction is equal to `mph / 100`. The `mph` attribute of the mount is a stat that's unique and can grow over time.

__Note that now, map points are considered to be 1 square mile big.__

## Testing Done
Everything's tested.

## Performance Impact
N/A

## Check-List
- [x] Code basic time traveling
- [x] Code in-depth coefficient updates
- [x] Add `mph` mounts attribute
- [x] Update BOW-Progression repository
- [x] Update wiki
